### PR TITLE
Version 0.6.0: Changes to command-line API for better semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2021-11-20
+
+### Added to 0.6.0
+
+- Modified `com.senzing.cmdline.CommandLineOption` to add `isSensitive()`
+  function with a default implementation based on the naming of the enum  
+  constant being either `PASSWORD` or ending in `_PASSWORD`.
+- Chnaged the semantics of `parseCommandLine()` function in 
+  `com.senzing.cmndline.CommandLineUtilites` so that it returns the `Map` 
+  describing the command-line options and takes an optional `List` to 
+  populate with `DeprecatedOptionWarning` instances if the caller is interested.
+
 ## [0.5.0] - 2021-11-16
 
 ### Added to 0.5.0 (Initial Public Prerelease)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `com.senzing.cmndline.CommandLineUtilites` so that it returns the `Map` 
   describing the command-line options and takes an optional `List` to 
   populate with `DeprecatedOptionWarning` instances if the caller is interested.
+- Fixed parameters and `throws` clause on `CommandLineParser.parseCommandLine()`
+  to better match `CommandLineUtilities.parseCommandLine()`
+- Fixed `throws` clause for `ParameterProcessor.process()` so that it now 
+  throws `BadOptionParameterException`.
 
 ## [0.5.0] - 2021-11-16
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-commons</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.0</version>
+  <version>0.6.0-SNAPSHOT</version>
   <name>Senzing Commons</name>
   <description>Utility classes and functions common to multiple Senzing projects.</description>
   <url>http://github.com/Senzing/senzing-commons-java</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-commons</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-SNAPSHOT</version>
+  <version>0.6.0</version>
   <name>Senzing Commons</name>
   <description>Utility classes and functions common to multiple Senzing projects.</description>
   <url>http://github.com/Senzing/senzing-commons-java</url>

--- a/src/main/java/com/senzing/cmdline/CommandLineParser.java
+++ b/src/main/java/com/senzing/cmdline/CommandLineParser.java
@@ -1,5 +1,6 @@
 package com.senzing.cmdline;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -12,8 +13,20 @@ public interface CommandLineParser {
    *
    * @param args The command-line arguments to parse.
    *
+   * @param deprecationWarnings The {@link List} to be populated with any
+   *                            {@link DeprecatedOptionWarning} instances that
+   *                            are generated, or <code>null</code> if the
+   *                            caller is not interested in deprecation
+   *                            warnings.
+   *
    * @return The {@link Map} of {@link CommandLineOption} keys to {@link Object}
    *         values describing the provided arguments.
+   *
+   * @throws CommandLineException If a command-line parsing/proecesing error
+   *                              occurs.
    */
-  Map<CommandLineOption, Object> parseCommandLine(String[] args);
+  Map<CommandLineOption, Object> parseCommandLine(
+      String[]                      args,
+      List<DeprecatedOptionWarning> deprecationWarnings)
+    throws CommandLineException;
 }

--- a/src/main/java/com/senzing/cmdline/ParameterProcessor.java
+++ b/src/main/java/com/senzing/cmdline/ParameterProcessor.java
@@ -16,9 +16,9 @@ public interface ParameterProcessor {
    * @return The {@link Object} or array of {@link Object} instances
    *         representing the processed parameters.
    *
-   * @throws IllegalArgumentException If the parameters are illegal in some
-   *                                  way.
+   * @throws BadOptionParametersException If the parameter(s) to the option are
+   *                                      illegal in some way.
    */
   Object process(CommandLineOption commandLineOption, List<String> params)
-    throws IllegalArgumentException;
+    throws BadOptionParametersException;
 }

--- a/src/test/java/com/senzing/cmdline/CommandLineUtilitiesTest.java
+++ b/src/test/java/com/senzing/cmdline/CommandLineUtilitiesTest.java
@@ -1,6 +1,7 @@
 package com.senzing.cmdline;
 
 import com.senzing.util.JsonUtils;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -659,6 +660,7 @@ public class CommandLineUtilitiesTest {
    */
   public List<Arguments> getParseCommandLineParameters() {
     List<Arguments> result = new LinkedList<>();
+    List emptyList = List.of();
 
     Map<CommandLineOption, CommandLineValue> defaultMap = Map.of(
       VERBOSE,
@@ -697,7 +699,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            expectedResult,
-                           null,
+                           emptyList,
                            null));
 
       result.add(arguments(ExtendedTestOption.class,
@@ -706,7 +708,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            expectedResult,
-                           null,
+                           emptyList,
                            null));
 
       args = new String[] { "-help" };
@@ -725,7 +727,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            expectedResult,
-                           null,
+                           emptyList,
                            null));
 
       result.add(arguments(ExtendedTestOption.class,
@@ -734,7 +736,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            expectedResult,
-                           null,
+                           emptyList,
                            null));
 
       args = new String[] { "--help", "--version" };
@@ -745,7 +747,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            ConflictingOptionsException.class));
 
       result.add(arguments(ExtendedTestOption.class,
@@ -754,7 +756,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            ConflictingOptionsException.class));
 
       args = new String[] { "-help", "-version" };
@@ -765,7 +767,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            ConflictingOptionsException.class));
 
       result.add(arguments(ExtendedTestOption.class,
@@ -774,7 +776,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            ConflictingOptionsException.class));
 
       args = new String[] { "--port", "9080", "--interface", "localhost" };
@@ -785,7 +787,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            NoPrimaryOptionException.class));
 
       result.add(arguments(ExtendedTestOption.class,
@@ -794,7 +796,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            NoPrimaryOptionException.class));
 
       args = new String[] { "--port", "9080", "5080", "--interface", "localhost" };
@@ -805,7 +807,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            BadOptionParameterCountException.class));
 
       result.add(arguments(ExtendedTestOption.class,
@@ -814,7 +816,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            BadOptionParameterCountException.class));
 
       args = new String[] { "--port", "9080", "--interface" };
@@ -825,7 +827,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            BadOptionParameterCountException.class));
 
       result.add(arguments(ExtendedTestOption.class,
@@ -834,7 +836,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            BadOptionParameterCountException.class));
 
       args = new String[] {"--config", "test.conf", "--url", "localhost:9080"};
@@ -885,7 +887,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            MissingDependenciesException.class));
 
       result.add(arguments(ExtendedTestOption.class,
@@ -894,7 +896,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            MissingDependenciesException.class));
 
       args = new String[] { "--config", "test.conf", "--url", "localhost:AB12" };
@@ -905,7 +907,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            BadOptionParametersException.class));
 
       result.add(arguments(ExtendedTestOption.class,
@@ -914,7 +916,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            BadOptionParametersException.class));
 
       args = new String[] { "--config", "test1.conf", "-config", "test2.conf" };
@@ -925,7 +927,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            RepeatedOptionException.class));
 
       result.add(arguments(ExtendedTestOption.class,
@@ -934,7 +936,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            RepeatedOptionException.class));
 
       args = new String[] { "--config", "test.conf", "--input", "input.json" };
@@ -945,7 +947,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            UnrecognizedOptionException.class));
 
       result.add(arguments(ExtendedTestOption.class,
@@ -954,7 +956,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            null,
-                           null,
+                           emptyList,
                            UnrecognizedOptionException.class));
 
       args = new String[] { "--config", "test.conf", "--table", "RECORDS" };
@@ -981,7 +983,7 @@ public class CommandLineUtilitiesTest {
                            ignoreOpts[0],
                            ignoreOpts[1],
                            expectedResult,
-                           null,
+                           emptyList,
                            null));
     }
 
@@ -1025,19 +1027,19 @@ public class CommandLineUtilitiesTest {
       }
 
       // declare the result
-      Map<CommandLineOption, CommandLineValue> map = new LinkedHashMap<>();
-      List<DeprecatedOptionWarning> list = null;
+      Map<CommandLineOption, CommandLineValue> map = null;
+      List<DeprecatedOptionWarning> list = new LinkedList<>();
 
       // determine which parseCommandLine() function to call
       if (ignoreEnv == null && ignoreEnvOption == null) {
-        list = parseCommandLine(optionClass, args, processor, map);
+        map = parseCommandLine(optionClass, args, processor, list);
 
       } else if (ignoreEnv == null) {
-        list = parseCommandLine(
-            optionClass, args, processor, ignoreEnvOption, map);
+        map = parseCommandLine(
+            optionClass, args, processor, ignoreEnvOption, list);
 
       } else {
-        list = parseCommandLine(optionClass, args, processor, ignoreEnv, map);
+        map = parseCommandLine(optionClass, args, processor, ignoreEnv, list);
       }
 
       // check if an exception was expected
@@ -1189,10 +1191,18 @@ public class CommandLineUtilitiesTest {
                              "--url",
                              "localhost/127.0.0.1:9080",
                              List.of("localhost:9080")));
+    optionValues.put(
+        PASSWORD,
+        new CommandLineValue(ENVIRONMENT,
+                             PASSWORD,
+                             "SENZING_TEST_PASSWORD",
+                             "secret",
+                             List.of("secret")));
 
     expectedResult = new LinkedHashMap<>(processedDefaults);
     expectedResult.put(CONFIG, new File("test.conf"));
     expectedResult.put(URL, "localhost/127.0.0.1:9080");
+    expectedResult.put(PASSWORD, "secret");
 
     expectedJson = JsonUtils.parseJsonObject(
         "{\"VERBOSE\": "
@@ -1208,7 +1218,11 @@ public class CommandLineUtilitiesTest {
             + "\"COMMAND_LINE\", \"via\": \"--config\"},"
             + "\"URL\": "
             + "{\"value\": \"localhost:9080\", \"source\": "
-            + "\"COMMAND_LINE\", \"via\": \"--url\"}}");
+            + "\"COMMAND_LINE\", \"via\": \"--url\"},"
+            + "\"PASSWORD\": "
+            + "{\"value\": \"" + REDACTED_SENSITIVE_VALUE
+            + "\", \"source\": \"ENVIRONMENT\","
+            + "\"via\": \"SENZING_TEST_PASSWORD\"}}");
 
     result.add(arguments(optionValues,
                          expectedResult,
@@ -1336,4 +1350,29 @@ public class CommandLineUtilitiesTest {
     }
   }
 
+  public List<Arguments> getSensitiveTestParameters() {
+    List<Arguments> result = new LinkedList<>();
+    result.add(arguments(PORT, false));
+    result.add(arguments(CONFIG, false));
+    result.add(arguments(INTERFACE, false));
+    result.add(arguments(URL, false));
+    result.add(arguments(PASSWORD, true));
+    result.add(arguments(DATABASE_PASSWORD, true));
+    return result;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getSensitiveTestParameters")
+  public <T extends CommandLineOption> void sensitiveTest(T       option,
+                                                          boolean sensitive)
+  {
+    try {
+      assertEquals(sensitive, option.isSensitive(),
+                   "Option sensitivity not as expected.");
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Failed sensitive option test: " + option);
+    }
+  }
 }

--- a/src/test/java/com/senzing/cmdline/ExtendedTestOption.java
+++ b/src/test/java/com/senzing/cmdline/ExtendedTestOption.java
@@ -15,7 +15,8 @@ public enum ExtendedTestOption
     implements CommandLineOption<ExtendedTestOption, TestOption>
 {
   SQS_QUEUE_URL("--sqs"),
-  DATABASE_TABLE("--table");
+  DATABASE_TABLE("--table"),
+  DATABASE_PASSWORD("--database-password");
 
   ExtendedTestOption(String cmdLineFlag) {
     this.cmdLineFlag = cmdLineFlag;
@@ -63,6 +64,7 @@ public enum ExtendedTestOption
     switch (this) {
       case SQS_QUEUE_URL:
       case DATABASE_TABLE:
+      case DATABASE_PASSWORD:
         return 1;
       default:
         return 0;
@@ -74,6 +76,7 @@ public enum ExtendedTestOption
     switch (this) {
       case SQS_QUEUE_URL:
       case DATABASE_TABLE:
+      case DATABASE_PASSWORD:
         return 1;
       default:
         return 0;
@@ -84,9 +87,22 @@ public enum ExtendedTestOption
   public Set<CommandLineOption> getConflicts() {
     switch (this) {
       case SQS_QUEUE_URL:
-        return Set.of(DATABASE_TABLE, HELP, VERSION);
+        return Set.of(DATABASE_TABLE, DATABASE_PASSWORD, HELP, VERSION);
       case DATABASE_TABLE:
         return Set.of(SQS_QUEUE_URL, HELP, VERSION);
+      default:
+        throw new IllegalStateException("Unrecognized option: " + this);
+    }
+  }
+
+  @Override
+  public Set<Set<CommandLineOption>> getDependencies() {
+    switch (this) {
+      case DATABASE_PASSWORD:
+        return Set.of(Set.of(DATABASE_TABLE));
+      case SQS_QUEUE_URL:
+      case DATABASE_TABLE:
+        return Set.of();
       default:
         throw new IllegalStateException("Unrecognized option: " + this);
     }
@@ -97,7 +113,9 @@ public enum ExtendedTestOption
    */
   private static class ParamProcessor implements ParameterProcessor
   {
-    public Object process(CommandLineOption option,  List<String> params) {
+    public Object process(CommandLineOption option,  List<String> params)
+      throws BadOptionParametersException
+    {
       if (option instanceof TestOption) {
         return TestOption.PARAMETER_PROCESSOR.process(option, params);
       }

--- a/src/test/java/com/senzing/cmdline/TestOption.java
+++ b/src/test/java/com/senzing/cmdline/TestOption.java
@@ -1,7 +1,5 @@
 package com.senzing.cmdline;
 
-import org.junit.jupiter.api.Test;
-
 import java.io.File;
 import java.net.InetAddress;
 import java.util.*;
@@ -17,7 +15,8 @@ public enum TestOption implements CommandLineOption<TestOption, TestOption> {
   CONFIG("--config"),
   PORT("--port"),
   INTERFACE("--interface"),
-  URL("--url");
+  URL("--url"),
+  PASSWORD("--password");
 
   TestOption(String cmdLineFlag) {
     this.cmdLineFlag = cmdLineFlag;
@@ -109,6 +108,7 @@ public enum TestOption implements CommandLineOption<TestOption, TestOption> {
       case PORT:
       case INTERFACE:
       case CONFIG:
+      case PASSWORD:
         return Set.of(HELP, VERSION);
       case IGNORE_ENV:
         return Set.of();
@@ -125,6 +125,8 @@ public enum TestOption implements CommandLineOption<TestOption, TestOption> {
       case VERBOSE:
       case CONFIG:
         return Collections.emptySet();
+      case PASSWORD:
+        return Set.of(Set.of(CONFIG, INTERFACE, PORT), Set.of(CONFIG, URL));
       case URL:
         return Set.of(Set.of(CONFIG));
       case PORT:
@@ -145,6 +147,7 @@ public enum TestOption implements CommandLineOption<TestOption, TestOption> {
       case INTERFACE:
       case CONFIG:
       case URL:
+      case PASSWORD:
         return 1;
       default:
         return 0;
@@ -158,6 +161,7 @@ public enum TestOption implements CommandLineOption<TestOption, TestOption> {
       case INTERFACE:
       case CONFIG:
       case URL:
+      case PASSWORD:
         return 1;
       default:
         return 0;
@@ -234,6 +238,9 @@ public enum TestOption implements CommandLineOption<TestOption, TestOption> {
 
           return address + ":"+ port;
         }
+
+        case PASSWORD:
+          return params.get(0);
 
         default:
           throw new IllegalArgumentException(

--- a/src/test/java/com/senzing/util/ErrorLogSuppressorTest.java
+++ b/src/test/java/com/senzing/util/ErrorLogSuppressorTest.java
@@ -13,7 +13,7 @@ import static com.senzing.util.ErrorLogSuppressor.*;
  * Tests for {@link ErrorLogSuppressor}.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-//@Execution(ExecutionMode.CONCURRENT)
+@Execution(ExecutionMode.CONCURRENT)
 public class ErrorLogSuppressorTest {
   @Test
   public void errorLogSuppressorTest() {


### PR DESCRIPTION
During integration of the new com.senzing.cmdline (Senzing Command-Line API) with the Senzing API Server, some deficiencies were discovered especially pertaining to the semantics.

Return values and parameters were swapped so that the result of parsing the command-line would be the Map describing the parse -- with deprecation options moving to be an optional list parameters that would be populated if specified as non-null.

Also added support for "sensitive" command-line options whose values would not be included in the JSON describing the startup parameters.