### PR TITLE
Version 2.0.1: Pom Dependency fix to exclude beta 3.0 releases of senzing-sdk-java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2022-03-07
+
+### Added to 2.0.1
+
+- Updates to `pom.xml` to prevent pulling beta versions of `senzing-sdk-java`
+  version `3.0.0` via the Maven dependency range.
+
 ## [2.0.0] - 2022-02-03
 
 ### Added to 2.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-commons</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <name>Senzing Commons</name>
   <description>Utility classes and functions common to multiple Senzing projects.</description>
   <url>http://github.com/Senzing/senzing-commons-java</url>
@@ -41,7 +41,7 @@
     <dependency>
      <groupId>com.senzing</groupId>
      <artifactId>g2</artifactId>
-       <version>[2.0.0-SNAPSHOT,3.0.0-SNAPSHOT)</version>
+       <version>[2.0.0-SNAPSHOT,2.999.999]</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>


### PR DESCRIPTION
Updates to `pom.xml` to prevent pulling beta versions of `senzing-sdk-java` version `3.0.0` via the Maven dependency range.