### PR TITLE
Fixed accidental keystroke typo in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>
-          <compi qlerArgs>
+          <compilerArgs>
             <arg>-Xlint:unchecked</arg>
             <arg>-Xlint:deprecation</arg>
           </compilerArgs>


### PR DESCRIPTION
Resolves #58 

Fix typo in `pom.xml` for version `3.1.3`
